### PR TITLE
Added 'PositionPlugin' to only render visible rows.

### DIFF
--- a/js/actions/local-action-creators.js
+++ b/js/actions/local-action-creators.js
@@ -1,4 +1,4 @@
-var AppDispatcher = require('../dispatcher/app-dispatcher');
+var AppDipatcher = require('../dispatcher/app-dispatcher');
 var Constants = require('../constants/constants');
 
 class LocalActions {
@@ -91,6 +91,18 @@ class LocalActions {
       column: column,
       change: change
     }
+
+    this.dispatcher.dispatch(action);
+  }
+
+  setScrollPosition(xScrollPosition, xScrollMax, yScrollPosition, yScrollMax) {
+    var action = {
+      actionType: Constants.XY_POSITION_CHANGED,
+      xScrollPosition: xScrollPosition,
+      xScrollMax: xScrollMax,
+      yScrollPosition: yScrollPosition,
+      yScrollMax: yScrollMax
+    };
 
     this.dispatcher.dispatch(action);
   }

--- a/js/stores/data-store.js
+++ b/js/stores/data-store.js
@@ -118,7 +118,9 @@ class DataStore extends StoreBoilerplate{
   /* HELPERS */
   get Helpers() {
     return {
-      getVisibleData() {
+      getVisibleData(state) {
+        state = state || this.state;
+
         return this.state.get('data');
       },
 

--- a/js/stores/data-store.js
+++ b/js/stores/data-store.js
@@ -35,7 +35,7 @@ class DataStore extends StoreBoilerplate{
       var wireUpAction = (property) => {
         for (var actionType in plugin[property]) {
           if (_actionHandlers.hasOwnProperty(actionType)) {
-            _actionHandlers[actionType][property].push(plugin[plugin][actionType])
+            _actionHandlers[actionType][property].push(plugin[property][actionType])
           } else {
             const options = {};
             options[property] = plugin[property].length > 0 ? plugin[property][actionType] : [plugin[property][actionType]];
@@ -44,8 +44,8 @@ class DataStore extends StoreBoilerplate{
         }
       }
 
-      wireUpAction("prePatches");
-      wireUpAction("postPatches");
+      wireUpAction("PrePatches");
+      wireUpAction("PostPatches");
 
       //add the plugin's overrides
       for(var actionType in plugin.RegisteredCallbacks) {
@@ -66,13 +66,13 @@ class DataStore extends StoreBoilerplate{
       let overridden = false;
       let actionState = _this.state;
       let continueIfUpdatingState = function(method){
-        actionState = method(action, actionState);
+        actionState = method(action, actionState, _this);
         return !!actionState;
       }
 
       if(_actionHandlers.hasOwnProperty(action.actionType)){
         _actionHandlers[action.actionType]
-          .prePatches
+          .PrePatches
           .every(continueIfUpdatingState);
 
         // If the action is forcing a change not to result in an emit, return.
@@ -80,20 +80,20 @@ class DataStore extends StoreBoilerplate{
 
         if(!!_actionHandlers[action.actionType].override) {
           overridden = true;
-          actionState = _actionHandlers[action.actionType].override(action, _this.state);
+          actionState = _actionHandlers[action.actionType].override(action, _this.state, _this);
         }
 
         if (actionState === null) { return; }
 
         _actionHandlers[action.actionType]
-          .postPatches
+          .PostPatches
           .every(continueIfUpdatingState);
 
         if (actionState === null) { return; }
       }
 
       if(!overridden) {
-        actionState = _this.RegisteredCallbacks[action.actionType](action, _this.state);
+        actionState = _this.RegisteredCallbacks[action.actionType](action, _this.state, _this);
       }
 
       if (actionState === null) { return; }
@@ -130,7 +130,7 @@ class DataStore extends StoreBoilerplate{
 
   static createActionHandler(properties) {
     if(properties)
-      return {prePatches: (properties.prePatches || []), postPatches: (properties.postPatches || []), override: properties.override || null}
+      return {PrePatches: (properties.prePatches || []), PostPatches: (properties.postPatches || []), override: properties.override || null}
   }
 }
 module.exports = DataStore;

--- a/js/stores/local-data-plugin.js
+++ b/js/stores/local-data-plugin.js
@@ -5,7 +5,7 @@ const LocalDataPlugin  = {
   initializeState(state) {
     //default state modifications for this plugin
     return state
-      .setIn(['pageProperties', 'pageSize'], 60)
+      .setIn(['pageProperties', 'pageSize'], 10)
       .setIn(['pageProperties', 'currentPage'], 1)
       .setIn(['sortProperties', 'sortColumns'], [])
       .setIn(['sortProperties', 'sortAscending'], true)

--- a/js/stores/local-data-plugin.js
+++ b/js/stores/local-data-plugin.js
@@ -31,7 +31,6 @@ const LocalDataPlugin  = {
       },
 
       GRIDDLE_GET_PAGE(action, state) {
-        debugger;
         return(LocalDataPlugin
           .getPage(state, action.pageNumber));
       },

--- a/js/stores/local-data-plugin.js
+++ b/js/stores/local-data-plugin.js
@@ -5,7 +5,7 @@ const LocalDataPlugin  = {
   initializeState(state) {
     //default state modifications for this plugin
     return state
-      .setIn(['pageProperties', 'pageSize'], 10)
+      .setIn(['pageProperties', 'pageSize'], 60)
       .setIn(['pageProperties', 'currentPage'], 1)
       .setIn(['sortProperties', 'sortColumns'], '[]')
       .setIn(['sortProperties', 'sortAscending'], 'true')

--- a/js/stores/local-data-plugin.js
+++ b/js/stores/local-data-plugin.js
@@ -74,21 +74,27 @@ const LocalDataPlugin  = {
   },
 
   Helpers: {
-      getVisibleData() {
+      getVisibleData(state) {
+        state = state || this.state;
+
         //get the max page / current page and the current page of data
-        const pageSize = this.state.getIn(['pageProperties', 'pageSize']);
-        const currentPage = this.state.getIn(['pageProperties', 'currentPage']);
-        return LocalDataPlugin.getDataSet(this.state)
+        const pageSize = state.getIn(['pageProperties', 'pageSize']);
+        const currentPage = state.getIn(['pageProperties', 'currentPage']);
+        return LocalDataPlugin.getDataSet(state)
           .skip(pageSize * (currentPage-1)).take(pageSize);
       },
 
-      hasNext() {
-        return this.state.getIn(['pageProperties', 'currentPage']) <
+      hasNext(state) {
+        state = state || this.state;
+
+        return state.getIn(['pageProperties', 'currentPage']) <
           this.state.getIn(['pageProperties', 'maxPage']);
       },
 
-      hasPrevious() {
-        return this.state.getIn(['pageProperties', 'currentPage']) > 1;
+      hasPrevious(state) {
+        state = state || this.state;
+
+        return state.getIn(['pageProperties', 'currentPage']) > 1;
       }
   },
 

--- a/js/stores/position-plugin.js
+++ b/js/stores/position-plugin.js
@@ -1,0 +1,94 @@
+'use strict';
+import StoreBoilerplate from './store-boilerplate';
+import Immutable from 'immutable';
+
+var defaultPositionState = {
+  xScrollChangePosition: 0,
+  yScrollChangePosition: 0,
+  renderedStartDisplayIndex: 0,
+  renderedEndDisplayIndex: 0,
+  tableHeight: 400,
+  tableWidth: 200,
+  rowHeight: 25,
+  defaultColumnWidth: 80,
+  infiniteScrollLoadTreshold: 50
+};
+
+class PositionPlugin extends StoreBoilerplate {
+  constructor(){
+    super();
+  }
+
+  initializeState(state) {
+    debugger;
+    //default state modifications for this plugin
+    return state
+      .set('position', Immutable.fromJS(defaultPositionState))
+      .set('renderedData', Immutable.fromJS([]));
+  }
+
+  get RegisteredCallbacks() {
+    return {
+      GRIDDLE_LOADED_DATA(action, state) {
+        return PositionPlugin.updateRenderedData(state);
+      },
+      GRIDDLE_NEXT_PAGE(action, state) {
+        return PositionPlugin.updateRenderedData(state);
+      },
+      GRIDDLE_PREVIOUS_PAGE(action, state) {
+        return PositionPlugin.updateRenderedData(state);
+      },
+      GRIDDLE_FILTERED(action, state) {
+        return PositionPlugin.updateRenderedData(state);
+      },
+      GRIDDLE_SORT(action, state) {
+        return PositionPlugin.updateRenderedData(state);
+      },
+      XY_POSITION_CHANGED(action, state) {
+        return PositionPlugin.updatePositionProperties(action, state);
+        return PositionPlugin.updateRenderedData(state);
+      }
+    };
+  }
+
+  get Helpers() {
+    return {
+      getRenderedData() {
+        return this.state.get('renderedData');
+      }
+    };
+  }
+
+  static shouldUpdateDrawnRows(action, currentPosition) {
+    return Math.abs(action.yScrollPosition - currentPosition.yScrollChangePosition) >= currentPosition.rowHeight;
+  }
+
+  static updatePositionProperties(action, state) {
+    var position = this.state.get('position');
+
+    if (PositionPlugin.shouldUpdateDrawnRows(action, position)) {
+      return null; // Indicate that this shouldn't result in an emit.
+    }
+
+    var adjustedHeight = position.rowHeight;
+    var visibleRecordCount = Math.ceil(position.tableHeight / adjustedHeight);
+
+    // Inspired by : http://jsfiddle.net/vjeux/KbWJ2/9/
+    position.renderedStartDisplayIndex = Math.max(0, Math.floor(action.yScrollPosition / adjustedHeight) - visibleRecordCount * 0.25);
+    position.renderedEndDisplayIndex = Math.min(position.renderedStartDisplayIndex + visibleRecordCount * 1.25, this.getVisibleData().length - 1) + 1;
+
+    return state
+      .setIn(['position', 'renderedStartDisplayIndex'], renderedStartDisplayIndex)
+      .setIn(['position', 'renderedEndDisplayIndex'], renderedEndDisplayIndex);
+  }
+
+  static updateRenderedData(state) {
+    let startDisplayIndex = state.getIn(['position', 'renderedStartDisplayIndex']) - 1;
+    return state
+      .set('renderedData', this.getVisibleData()
+                            .skip(startDisplayIndex)
+                            .take(state.getIn(['position', 'renderedEndDisplayIndex']) - startDisplayIndex));
+  }
+}
+
+export default PositionPlugin;

--- a/js/stores/position-plugin.js
+++ b/js/stores/position-plugin.js
@@ -6,7 +6,7 @@ var defaultPositionState = {
   xScrollChangePosition: 0,
   yScrollChangePosition: 0,
   renderedStartDisplayIndex: 0,
-  renderedEndDisplayIndex: 10,
+  renderedEndDisplayIndex: 20,
   tableHeight: 400,
   tableWidth: 200,
   rowHeight: 25,
@@ -29,7 +29,7 @@ const PositionPlugin  = {
     }
   },
 
-  PrePatches: {
+  PostPatches: {
     GRIDDLE_LOADED_DATA(action, state, store) {
       return PositionPlugin.updateRenderedData(state, store);
     },
@@ -48,7 +48,8 @@ const PositionPlugin  = {
   },
 
   Helpers: {
-    getRenderedData() {
+    getRenderedData(state) {
+      state = state || this.state;
       return this.state.get('renderedData');
     }
   },
@@ -72,7 +73,7 @@ const PositionPlugin  = {
 
     // Inspired by : http://jsfiddle.net/vjeux/KbWJ2/9/
     let renderedStartDisplayIndex = Math.max(0, Math.floor(action.yScrollPosition / adjustedHeight) - visibleRecordCount * 0.25);
-    let renderedEndDisplayIndex = Math.min(renderedStartDisplayIndex + visibleRecordCount * 1.25, store.getVisibleData().length - 1) + 1;
+    let renderedEndDisplayIndex = Math.min(renderedStartDisplayIndex + visibleRecordCount * 1.25, store.getVisibleData(state).length - 1) + 1;
 
     return state
       .setIn(['position', 'renderedStartDisplayIndex'], renderedStartDisplayIndex)
@@ -84,7 +85,7 @@ const PositionPlugin  = {
   updateRenderedData(state, store) {
     let startDisplayIndex = state.getIn(['position', 'renderedStartDisplayIndex']); // -1
     return state
-      .set('renderedData', store.getVisibleData()
+      .set('renderedData', store.getVisibleData(state)
                             .skip(startDisplayIndex)
                             .take(state.getIn(['position', 'renderedEndDisplayIndex']) - startDisplayIndex));
   }

--- a/js/views/other-fake-griddle.js
+++ b/js/views/other-fake-griddle.js
@@ -49,6 +49,7 @@ class FakeGriddle extends React.Component {
   }
 
   componentDidMount() {
+    debugger;
     if (this.props.data){
       this.localActions.loadData(this.props.data);
     }

--- a/js/views/other-fake-griddle.js
+++ b/js/views/other-fake-griddle.js
@@ -7,6 +7,7 @@ import Flux from 'flux';
 import LocalActions from '../actions/local-action-creators';
 import DataStore from '../stores/data-store';
 import LocalDataPlugin from '../stores/local-data-plugin';
+import PositionPlugin from '../stores/position-plugin';
 
 class SortButton extends React.Component {
   constructor(props) {
@@ -33,11 +34,11 @@ class FakeGriddle extends React.Component {
     super(props);
 
     this.dispatcher = new Flux.Dispatcher();
-    this.dataStore = new DataStore(this.dispatcher, [LocalDataPlugin]);
+    this.dataStore = new DataStore(this.dispatcher, [LocalDataPlugin, PositionPlugin]);
     this.localActions = new LocalActions(this.dispatcher);
 
     this.state = {};
-    this.state.data = this.dataStore.getVisibleData();
+    this.state.data = this.dataStore.getRenderedData();
     this.state.hasNext = false;
     this.state.hasPrevious = false;
     //TODO: look into autobinding plugins
@@ -88,7 +89,11 @@ class FakeGriddle extends React.Component {
         </tr>
       });
 
-
+    var wrapperStyle = {
+      'height': '500px',
+      'width': '300px',
+      'overflow': 'scroll',
+    };
     var actionCreator = this.localActions;
     var keys = data.length > 0 ? Object.keys(data[0]) : null;
     var thead = !!keys ?
@@ -103,7 +108,7 @@ class FakeGriddle extends React.Component {
         </thead>
       : null;
     return (
-      <div>
+      <div style={wrapperStyle}>
         <input type='text' placeholder='filter' onChange={this.handleFilter} />
         <table>
           {thead}

--- a/js/views/other-fake-griddle.js
+++ b/js/views/other-fake-griddle.js
@@ -8,6 +8,7 @@ import LocalActions from '../actions/local-action-creators';
 import DataStore from '../stores/data-store';
 import LocalDataPlugin from '../stores/local-data-plugin';
 import PositionPlugin from '../stores/position-plugin';
+import SpacerRow from './spacer-row';
 
 class SortButton extends React.Component {
   constructor(props) {
@@ -46,15 +47,13 @@ class FakeGriddle extends React.Component {
     this.handlePrevious = this.handlePrevious.bind(this);
     this.handleNext = this.handleNext.bind(this);
     this.handleFilter = this.handleFilter.bind(this);
+    this.gridScroll = this.gridScroll.bind(this);
   }
 
   componentDidMount() {
-    debugger;
     if (this.props.data){
       this.localActions.loadData(this.props.data);
     }
-
-    this.gridScroll = this.gridScroll.bind(this);
   }
 
   handlePrevious() {
@@ -85,16 +84,17 @@ class FakeGriddle extends React.Component {
 
     var rows =
       _.map(data, (item) => {
-        return <tr>
+        return <tr key={item.id}>
           {_.map(_.keys(item), function(key){
-            return <td>{item[key]}</td>
+            return <td key={item.id + '-' + key}>{item[key]}</td>
           })}
         </tr>
       });
 
+    var positionData = this.dataStore.getPositionData();
     var wrapperStyle = {
-      'height': '500px',
-      'width': '300px',
+      'height': positionData.tableHeight + 'px',
+      'width': positionData.tableWidth + 'px',
       'overflow': 'scroll',
     };
     var actionCreator = this.localActions;
@@ -103,7 +103,7 @@ class FakeGriddle extends React.Component {
         <thead>
           {_.map(keys, function(key) {
             return (
-              <th>
+              <th key={'col-' + key}>
                 <SortButton column={key} action={actionCreator} />
               </th>);
           })}
@@ -116,7 +116,9 @@ class FakeGriddle extends React.Component {
         <table>
           {thead}
           <tbody>
+            <SpacerRow placement='top' positionData={positionData} />
             {rows}
+            <SpacerRow placement='bottom' positionData={positionData} />
           </tbody>
         </table>
         { this.state.hasPrevious ? <button onClick={this.handlePrevious}>PREVIOUS</button> : null }

--- a/js/views/other-fake-griddle.js
+++ b/js/views/other-fake-griddle.js
@@ -52,6 +52,8 @@ class FakeGriddle extends React.Component {
     if (this.props.data){
       this.localActions.loadData(this.props.data);
     }
+
+    this.gridScroll = this.gridScroll.bind(this);
   }
 
   handlePrevious() {
@@ -68,7 +70,7 @@ class FakeGriddle extends React.Component {
 
   dataChange() {
     this.setState({
-      data: this.dataStore.getVisibleData(),
+      data: this.dataStore.getRenderedData(),
       hasNext: this.dataStore.hasNext(),
       hasPrevious: this.dataStore.hasPrevious()
     });
@@ -108,7 +110,7 @@ class FakeGriddle extends React.Component {
         </thead>
       : null;
     return (
-      <div style={wrapperStyle}>
+      <div ref='scrollable' onScroll={this.gridScroll} style={wrapperStyle}>
         <input type='text' placeholder='filter' onChange={this.handleFilter} />
         <table>
           {thead}
@@ -119,6 +121,13 @@ class FakeGriddle extends React.Component {
         { this.state.hasPrevious ? <button onClick={this.handlePrevious}>PREVIOUS</button> : null }
         { this.state.hasNext ? <button onClick={this.handleNext}>NEXT</button> : null }
       </div>);
+  }
+
+  gridScroll() {
+    if (this.refs.scrollable) {
+      let scrollableNode = this.refs.scrollable.getDOMNode();
+      this.localActions.setScrollPosition(scrollableNode.scrollLeft, scrollableNode.scrollWidth, scrollableNode.scrollTop, scrollableNode.scrollHeight);
+    }
   }
 }
 

--- a/js/views/spacer-row.js
+++ b/js/views/spacer-row.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var React = require('react');
+
+class SpacerRow extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    let height = 0, spacerRowStyle = {};
+    if (this.props.positionData) {
+      // Get the length of rows that the spacer row will represent.
+      let spacerRowCount = this.props.placement === 'top' ? this.props.positionData.renderedStartDisplayIndex :
+        this.props.positionData.visibleDataLength - this.props.positionData.renderedEndDisplayIndex;
+
+      // Get the height in pixels.
+      height = this.props.positionData.rowHeight * spacerRowCount;
+    }
+
+    spacerRowStyle.height = height + 'px';
+
+    return (
+      <tr key={this.props.placement + '-' + height} style={spacerRowStyle}></tr>
+    );
+  }
+}
+SpacerRow.defaultProps  = {
+  'placement': 'top',
+  'positionData': null
+};
+
+module.exports = SpacerRow;

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "The core code used in the griddle-react grid. ",
   "main": "build/griddle.js",
   "scripts": {
-    "test": "karma start --browsers PhantomJS",
+    "test": "./node_modules/.bin/karma start --browsers PhantomJS",
     "start": "node server.js",
-    "test-debug": "karma start --browsers Chrome",
-    "dist": "webpack --config webpack-dist.config.js"
+    "test-debug": "./node_modules/.bin/karma start --browsers Chrome",
+    "dist": "./node_modules/.bin/webpack --config webpack-dist.config.js"
   },
   "author": "Ryan Lanciaux && Joel Lanciaux",
   "license": "MIT",
@@ -18,9 +18,10 @@
     "coffee-script": "^1.9.2",
     "jasmine-core": "^2.2.0",
     "jsx-loader": "~0.12.2",
-    "karma": "^0.12.31",
+    "karma": "^0.12.32",
     "karma-babel-preprocessor": "^5.0.1",
     "karma-chrome-launcher": "^0.1.8",
+    "karma-cli": "0.0.4",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-webpack": "^1.5.0",


### PR DESCRIPTION
There are a couple additional updates that came along with this, such as the need to pass the 'data-store' instance into its plugins + adding the ability for plugin action handlers to indicate that the store shouldn't fire an emit.
